### PR TITLE
fix bug utils tab being reloaded whenever a request is made

### DIFF
--- a/packages/insomnia/src/ui/components/panes/request-pane.tsx
+++ b/packages/insomnia/src/ui/components/panes/request-pane.tsx
@@ -341,10 +341,13 @@ export const RequestPane: FC<Props> = ({
           }
         >
           <ErrorBoundary
-            key={uniqueKey}
+            key="requestExtend"
             errorClassName="font-error pad text-center"
           >
-            <RequestUtilsEditors activeTab={activeUtilTab} setLoading={setLoading} />
+            <RequestUtilsEditors
+              activeTab={activeUtilTab}
+              setLoading={setLoading}
+            />
           </ErrorBoundary>
         </TabItem>
       </Tabs>


### PR DESCRIPTION
- Add static key to ErrorBoundary - parent component of RequestUtilsTabEditors component
