### PR TITLE
DEV011 - fix utils tab not being changed when switching request

### DIFF
--- a/packages/insomnia/src/ui/components/panes/request-pane.tsx
+++ b/packages/insomnia/src/ui/components/panes/request-pane.tsx
@@ -341,7 +341,7 @@ export const RequestPane: FC<Props> = ({
           }
         >
           <ErrorBoundary
-            key="requestExtend"
+            key={requestId}
             errorClassName="font-error pad text-center"
           >
             <RequestUtilsEditors


### PR DESCRIPTION
- Set requestId as key of ErrorBoundary - parent component of RequestUtilsTabEditors component
