### PR TITLE
DEV017 disable chevron when there is no setters

### DIFF
--- a/packages/insomnia/src/ui/components/editors/utils/setter-event-row-editor.tsx
+++ b/packages/insomnia/src/ui/components/editors/utils/setter-event-row-editor.tsx
@@ -324,7 +324,7 @@ const SetterEventRowEditor: FC<Props> = ({
           onClick={_handleToggle}
           className='space-right'
         >
-          {isToggled ? (
+          {isToggled && pairs.length ? (
             <i className='fa fa-chevron-down' />
           ) : (
             <i className='fa fa-chevron-right' />

--- a/packages/insomnia/src/ui/components/editors/utils/setter-event-row-editor.tsx
+++ b/packages/insomnia/src/ui/components/editors/utils/setter-event-row-editor.tsx
@@ -319,7 +319,11 @@ const SetterEventRowEditor: FC<Props> = ({
   return (
     <StyledContainer>
       <div className='event-header'>
-        <Button onClick={_handleToggle} className='space-right'>
+        <Button
+          disabled={!pairs.length}
+          onClick={_handleToggle}
+          className='space-right'
+        >
           {isToggled ? (
             <i className='fa fa-chevron-down' />
           ) : (


### PR DESCRIPTION
<!--
Please open an [Issue](https://github.com/kong/insomnia/issues/new) first to discuss new
features or non-trivial changes. Please provide as much detail as possible on the change as
possible including general description, implementation details, potential shortcomings, etc.

If this PR closes an issue, please mention "Closes #XX" where #XX is the issue number.

If this PR fixes a bug or regression, please make sure to add a test.
-->
Chevron in setter will be disabled if there is no setter 
![Screenshot 2024-01-08 at 14 02 59](https://github.com/DatHoang192/insomnia/assets/73072113/169a6c86-9d98-476f-8764-924c6caaa790)
