### PR TITLE
DEV087 - fix overflow dataset automatically scroll to bottom

### DIFF
--- a/packages/insomnia/src/ui/components/codemirror/one-line-editor.tsx
+++ b/packages/insomnia/src/ui/components/codemirror/one-line-editor.tsx
@@ -24,6 +24,7 @@ export interface OneLineEditorProps {
   readOnly?: boolean;
   type?: string;
   onPaste?: (text: string) => void;
+  isDatasetEditor?: boolean;
 }
 
 export interface OneLineEditorHandle {
@@ -40,6 +41,7 @@ export const OneLineEditor = forwardRef<OneLineEditorHandle, OneLineEditorProps>
   readOnly,
   type,
   onPaste,
+  isDatasetEditor,
 }, ref) => {
   const textAreaRef = useRef<HTMLTextAreaElement>(null);
   const codeMirror = useRef<CodeMirror.EditorFromTextArea | null>(null);
@@ -167,7 +169,7 @@ export const OneLineEditor = forwardRef<OneLineEditorHandle, OneLineEditorProps>
     codeMirror.current.on('copy', preventDefault);
     codeMirror.current.on('cut', preventDefault);
     codeMirror.current.on('dragstart', preventDefault);
-    codeMirror.current.setCursor({ line: -1, ch: -1 });
+    isDatasetEditor || codeMirror.current.setCursor({ line: -1, ch: -1 });
 
     // Actually set the value
     codeMirror.current?.setValue(defaultValue || '');

--- a/packages/insomnia/src/ui/components/editors/utils/dataset-row-editor.tsx
+++ b/packages/insomnia/src/ui/components/editors/utils/dataset-row-editor.tsx
@@ -492,6 +492,7 @@ const DatasetRowEditor: FC<Props> = ({
               handleGetAutocompleteNameConstants={getCommonHeaderNames}
               handleGetAutocompleteValueConstants={getCommonHeaderValues}
               onChange={handleKeyValueUpdate}
+              isDatasetEditor={true}
             />
           )}
           {!baseDataset?.length && <span>Update base dataset first</span>}

--- a/packages/insomnia/src/ui/components/key-value-editor/key-value-editor.tsx
+++ b/packages/insomnia/src/ui/components/key-value-editor/key-value-editor.tsx
@@ -41,6 +41,7 @@ interface Props {
   }[]) => void;
   pairs: Pair[];
   valuePlaceholder?: string;
+  isDatasetEditor?: boolean;
 }
 
 export const KeyValueEditor: FC<Props> = ({
@@ -56,6 +57,7 @@ export const KeyValueEditor: FC<Props> = ({
   onChange,
   pairs,
   valuePlaceholder,
+  isDatasetEditor,
 }) => {
   // We should make the pair.id property required and pass them in from the parent
   // smelly
@@ -162,6 +164,7 @@ export const KeyValueEditor: FC<Props> = ({
               value: '',
               description: '',
             }])}
+            isDatasetEditor={isDatasetEditor}
           />
         ))}
       </ul>

--- a/packages/insomnia/src/ui/components/key-value-editor/row.tsx
+++ b/packages/insomnia/src/ui/components/key-value-editor/row.tsx
@@ -45,6 +45,7 @@ interface Props {
   keyWidth?: React.CSSProperties;
   readOnlyKey?: boolean;
   ignoreSuggestKey?: boolean;
+  isDatasetEditor?: boolean;
 }
 
 export const Row: FC<Props> = ({
@@ -67,6 +68,7 @@ export const Row: FC<Props> = ({
   keyWidth,
   readOnlyKey,
   ignoreSuggestKey,
+  isDatasetEditor,
 }) => {
   const { enabled } = useNunjucksEnabled();
 
@@ -105,6 +107,7 @@ export const Row: FC<Props> = ({
             getAutocompleteConstants={ignoreSuggestKey ? undefined : () => handleGetAutocompleteNameConstants?.(pair) || []}
             readOnly={readOnly || readOnlyKey}
             onChange={name => onChange({ ...pair, name })}
+            isDatasetEditor={isDatasetEditor}
           />
         </div>
         <div
@@ -147,6 +150,7 @@ export const Row: FC<Props> = ({
               onChange={value => onChange({ ...pair, value })}
                   getAutocompleteConstants={ignoreSuggestKey ? undefined : () => handleGetAutocompleteNameConstants?.(pair) || []}
                   readOnly={readOnly || readOnlyKey}
+              isDatasetEditor={isDatasetEditor}
             />
           )
           }
@@ -164,6 +168,7 @@ export const Row: FC<Props> = ({
               placeholder={descriptionPlaceholder || 'Description'}
               defaultValue={pair.description || ''}
               onChange={description => onChange({ ...pair, description })}
+              isDatasetEditor={isDatasetEditor}
             />
           </div>
         ) : null}


### PR DESCRIPTION
Add new prop _isDatasetEditor_ to **KeyValueEditor**, **Row**, **OneLineEditor** components to prevent _codeMirror.setCursor_ from being triggered in **DatasetRowEditor** component
